### PR TITLE
Validate/strip traceparent before echoing into response header (CWE-113)

### DIFF
--- a/vz-licencecheck-service/src/main/java/ch/admin/astra/vz/lc/integration/verifierservice/client/filter/E2ETraceContextFilter.java
+++ b/vz-licencecheck-service/src/main/java/ch/admin/astra/vz/lc/integration/verifierservice/client/filter/E2ETraceContextFilter.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.util.regex.Pattern;
 
 /**
  * Copies the traceparent header from request to response.
@@ -23,6 +24,15 @@ public class E2ETraceContextFilter extends OncePerRequestFilter {
 
     public static final String TRACEPARENT = "traceparent";
 
+    /**
+     * W3C trace-context {@code traceparent} format: {@code version-traceId-parentId-flags}
+     * (see <a href="https://www.w3.org/TR/trace-context/#traceparent-header-field-values">spec</a>).
+     * Validating against it before echoing the value prevents HTTP response splitting (CWE-113),
+     * since a well-formed value cannot contain CR/LF or other injection characters.
+     */
+    private static final Pattern TRACEPARENT_PATTERN =
+            Pattern.compile("^[0-9a-fA-F]{2}-[0-9a-fA-F]{32}-[0-9a-fA-F]{16}-[0-9a-fA-F]{2}$");
+
     @Override
     protected void doFilterInternal(HttpServletRequest request,
                                     HttpServletResponse response,
@@ -32,7 +42,15 @@ public class E2ETraceContextFilter extends OncePerRequestFilter {
                 request.getMethod(), request.getRequestURI(),
                 request.getHeaderNames());
 
-        response.setHeader(TRACEPARENT, request.getHeader(TRACEPARENT));
+        String traceparent = request.getHeader(TRACEPARENT);
+        if (traceparent != null) {
+            // Strip any CR/LF first (defuses HTTP response splitting, CWE-113), then accept the value
+            // only if it matches the strict W3C traceparent format before echoing it back.
+            String sanitized = traceparent.replaceAll("[\\r\\n]", "");
+            if (TRACEPARENT_PATTERN.matcher(sanitized).matches()) {
+                response.setHeader(TRACEPARENT, sanitized);
+            }
+        }
         filterChain.doFilter(request, response);
     }
 


### PR DESCRIPTION
**Security hardening (CWE-113, HTTP response splitting).** `E2ETraceContextFilter` echoed an inbound `traceparent` value into a response header without sanitisation. Now strips CR/LF and validates against the W3C `traceparent` format before echoing; malformed values are dropped. Defense-in-depth against header/log injection.

---
**Notes**
- Snyk steps need maintainer-side `SNYK_TOKEN`/`SNYK_ORG` secrets; fork-PR CI runs only after a maintainer clicks *Approve and run*.
- DCO: commit signed off by Daniel Casota.